### PR TITLE
Allow both `modifier key` and `npmb`

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -387,11 +387,11 @@ PlasmaCore.Dialog {
             engine: "keystate"
             connectedSources: {
                 let sources = []
-                if (config.modifierEnabled) {
-                    sources.push(modifierKeys[config.modifierKey])
-                }
                 if (config.npmbEnabled) {
                     sources = sources.concat(["Left Button", "Right Button", "Middle Button"])
+                }
+                if (config.modifierEnabled) {
+                    sources.push(modifierKeys[config.modifierKey])
                 }
                 return sources
             }


### PR DESCRIPTION
Reordered the `connectedSources` method so that we can have the sources of both `config.modifierEnabled` and `config.npmbEnabled`