### PR TITLE
Fix some bugs with multimonitor

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -145,6 +145,7 @@ PlasmaCore.Dialog {
                 client.layout === layout &&
                 client.desktop === workspace.currentDesktop &&
                 client.activity === workspace.currentActivity &&
+                client.screen === workspace.activeScreen &&
                 client.normalWindow) {
                     windows.push(client)
                 }
@@ -176,6 +177,7 @@ PlasmaCore.Dialog {
         
         log("Moving client " + client.resourceClass.toString() + " to zone " + zone)
 
+        refreshClientArea()
         saveWindowGeometries(client, zone)
 
         // move client to zone


### PR DESCRIPTION
1. Switching windows is now restricted to per monitor
2. When using zone assigning shortcuts (numbers and arrows), the windows are now moved within the screen they are in instead of the previously active monitor