### PR TITLE
Fix logic for determining a window is moved

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -21,6 +21,7 @@ PlasmaCore.Dialog {
     // properties
     property bool shown: false
     property bool moving: false
+    property bool moved: false
     property bool resizing: false
     property var clientArea: {}
     property var cachedClientArea: {}
@@ -617,12 +618,14 @@ PlasmaCore.Dialog {
                         
                         cachedClientArea = clientArea
                         moving = true
+                        moved = false
                         resizing = false
                         log("Move start " + client.resourceClass.toString())
                         mainDialog.show()
                     }
                     if (client.resize) {
                         moving = false
+                        moved = false
                         resizing = true
                         // client resizing
                     }
@@ -634,6 +637,7 @@ PlasmaCore.Dialog {
                 
                 if (client.resizeable) {
                     if (moving && checkFilter(client)) {
+                        moved = true
                         if (config.rememberWindowGeometries && client.zone != -1) {
                             if (client.oldGeometry) {
                                 let geometry = client.oldGeometry
@@ -655,17 +659,20 @@ PlasmaCore.Dialog {
             function onClientFinishUserMovedResized(client) {
                 if (moving) {
                     log("Move end " + client.resourceClass.toString())
-                    if (shown) {
-                        moveClientToZone(client, highlightedZone)
-                    } else {
-                        saveWindowGeometries(client, -1)
-                    }                    
+                    if (moved) {
+                        if (shown) {
+                            moveClientToZone(client, highlightedZone)
+                        } else {
+                            saveWindowGeometries(client, -1)
+                        }
+                    }
                     hide()
                 }
                 if (resizing) {
                     // client resizing
                 }
                 moving = false
+                moved = false
                 resizing = false
             }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -146,7 +146,7 @@ PlasmaCore.Dialog {
                 client.layout === layout &&
                 client.desktop === workspace.currentDesktop &&
                 client.activity === workspace.currentActivity &&
-                client.screen === workspace.activeScreen &&
+                client.screen === workspace.activeClient.screen &&
                 client.normalWindow) {
                     windows.push(client)
                 }
@@ -178,7 +178,7 @@ PlasmaCore.Dialog {
         
         log("Moving client " + client.resourceClass.toString() + " to zone " + zone)
 
-        refreshClientArea()
+        clientArea = workspace.clientArea(KWin.FullScreenArea, client.screen, workspace.currentDesktop)
         saveWindowGeometries(client, zone)
 
         // move client to zone


### PR DESCRIPTION
Better logic for determining a window is actually moved, in which case the zone is set to -1. Otherwise if the window is not actually moved the zone is unchanged.

The problem is that for some applications (e.g., Chrome), simply clicking on the title bar (not dragging) the script is signaled that the window is "moving" and thus when the mouse button is released, its zone will be set to -1 regardless whether the window is moved or not. This patch creates a `moved` variable to track if the window is actually moved, and if not does not reset the window's zone.