### PR TITLE
Add ability to switch to window in zone

### DIFF
--- a/src/contents/ui/components/Shortcuts.qml
+++ b/src/contents/ui/components/Shortcuts.qml
@@ -80,6 +80,22 @@ Item {
         }
     }
 
+    signal switchToWindowInZone(int zone)
+
+    Repeater {
+        model: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        delegate: Item {
+            ShortcutHandler {
+                name: "KZones: Switch to window in zone " + modelData
+                text: "KZones: Switch to window in zone " + modelData
+                sequence: "Ctrl+Alt+Shift+Num+" + modelData
+                onActivated: {
+                    switchToWindowInZone(modelData - 1)
+                }
+            }
+        }
+    }
+
     signal moveActiveWindowToZone(int zone)
 
     Repeater {

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -535,6 +535,10 @@ PlasmaCore.Dialog {
         onSwitchToPreviousWindowInCurrentZone: {
             switchWindowInZone(Workspace.activeWindow.zone, Workspace.activeWindow.layout, true);
         }
+
+        onSwitchToWindowInZone: {
+            switchWindowInZone(zone, Workspace.activeWindow.layout);
+        }
         
         onMoveActiveWindowToZone: {
             moveClientToZone(Workspace.activeWindow, zone);


### PR DESCRIPTION
This adds keyboard shortcuts to directly select a window in a zone. The default shortcuts I used is a bit clunky, I'm definitely open to suggestions for better ones.

Note that if the window in the selected zone is already active, it will cycle through the windows, same as `switchToNextWindowInCurrentZone`. That is on purpose, since that is the behavior I personally prefer, but I'm open to making that configurable if desired.
