### PR TITLE
Add "Closest to Zone Center" option and implement zone selection logic

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -116,6 +116,78 @@
                 &quot;width&quot;: 50
             }
         ]
+    },
+    {
+        &quot;name&quot;: &quot;Ultra Wide Overlapped Grid&quot;,
+        &quot;padding&quot;: 0,
+        &quot;zones&quot;: [
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 25,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 50
+            },
+            {
+                &quot;x&quot;: 75,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 50
+            },
+            {
+                &quot;x&quot;: 50,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 50
+            },
+            {
+                &quot;x&quot;: 25,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 50,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 50,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 75,
+                &quot;y&quot;: 50,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 75,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            }
+        ]
     }
 ]
             </default>

--- a/src/contents/ui/config.ui
+++ b/src/contents/ui/config.ui
@@ -168,6 +168,11 @@
                 <string>My cursor is anywhere in the zone</string>
                </property>
               </item>
+              <item>
+               <property name="text">
+                <string>My cursor is closest to the zone center</string>
+               </property>
+              </item>
              </widget>
             </item>
             <item row="2" column="0">
@@ -408,6 +413,78 @@
                 &quot;y&quot;: 0,
                 &quot;height&quot;: 50,
                 &quot;width&quot;: 50
+            }
+        ]
+    },
+    {
+        &quot;name&quot;: &quot;Ultra Wide Overlapped Grid&quot;,
+        &quot;padding&quot;: 0,
+        &quot;zones&quot;: [
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 25,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 50
+            },
+            {
+                &quot;x&quot;: 75,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 50
+            },
+            {
+                &quot;x&quot;: 50,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 50
+            },
+            {
+                &quot;x&quot;: 25,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 50,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 100,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 50,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 0,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 75,
+                &quot;y&quot;: 50,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
+            },
+            {
+                &quot;x&quot;: 75,
+                &quot;y&quot;: 0,
+                &quot;height&quot;: 50,
+                &quot;width&quot;: 25
             }
         ]
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -29,6 +29,7 @@ PlasmaCore.Dialog {
     property var activeScreen: null
     property var config: ({})
     property bool showZoneOverlay: config.zoneOverlayShowWhen == 0
+    property bool useClosestZoneCenter: config.zoneOverlayHighlightTarget == 2
     property var errors: []
 
     title: "KZones Overlay"
@@ -145,6 +146,31 @@ PlasmaCore.Dialog {
             width: item.width * item.scale,
             height: item.height * item.scale
         });
+    }
+
+    function findClosestZone(zones, cursorPos, clientArea) {
+        let closestZone = -1;
+        let closestDistance = Infinity;
+        
+        for (let zoneIndex = 0; zoneIndex < zones.length; zoneIndex++) {
+            const zone = zones[zoneIndex];
+            const zoneCenter = {
+                x: (zone.x + zone.width / 2) / 100 * clientArea.width + clientArea.x,
+                y: (zone.y + zone.height / 2) / 100 * clientArea.height + clientArea.y
+            };
+            
+            const distance = Math.sqrt(
+                Math.pow(cursorPos.x - zoneCenter.x, 2) + 
+                Math.pow(cursorPos.y - zoneCenter.y, 2)
+            );
+            
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                closestZone = zoneIndex;
+            }
+        }
+        
+        return closestZone;
     }
 
     function checkFilter(client) {
@@ -719,11 +745,16 @@ PlasmaCore.Dialog {
                 // zone overlay
                 const currentZones = repeaterLayout.itemAt(currentLayout)
                 if (config.enableZoneOverlay && showZoneOverlay && !zoneSelector.expanded) {
-                    currentZones.repeater.model.forEach((zone, zoneIndex) => {
-                        if (isHovering(currentZones.repeater.itemAt(zoneIndex).children[config.zoneOverlayHighlightTarget])) {
-                            hoveringZone = zoneIndex;
-                        }
-                    });
+                    if (useClosestZoneCenter) {
+                        const zones = config.layouts[currentLayout].zones;
+                        hoveringZone = findClosestZone(zones, Workspace.cursorPos, clientArea);
+                    } else {
+                        currentZones.repeater.model.forEach((zone, zoneIndex) => {
+                            if (isHovering(currentZones.repeater.itemAt(zoneIndex).children[config.zoneOverlayHighlightTarget])) {
+                                hoveringZone = zoneIndex;
+                            }
+                        });
+                    }
                 }
 
                 // zone selector
@@ -753,27 +784,33 @@ PlasmaCore.Dialog {
                     if (Workspace.cursorPos.x <= clientArea.x + triggerDistance || Workspace.cursorPos.x >= clientArea.x + clientArea.width - triggerDistance || Workspace.cursorPos.y <= clientArea.y + triggerDistance || Workspace.cursorPos.y >= clientArea.y + clientArea.height - triggerDistance) {
                         const padding = config.layouts[currentLayout].padding || 0;
                         const halfPadding = padding/2;
-                        currentZones.repeater.model.forEach((zone, zoneIndex) => {
-                            const zoneItem = currentZones.repeater.itemAt(zoneIndex);
-                            const itemGlobal = zoneItem.mapToGlobal(Qt.point(0, 0));
-                            let zoneGeometry = {
-                                x: itemGlobal.x - padding/2,
-                                y: itemGlobal.y - padding/2,
-                                width: zoneItem.width + padding,
-                                height: zoneItem.height + padding
-                             };
-                            if(zoneGeometry.x <= halfPadding ) { zoneGeometry.x = 0; zoneGeometry.width += padding; }   //adjust most left edge
-                            if(zoneGeometry.y <= halfPadding ) { zoneGeometry.y = 0; zoneGeometry.height += padding; }  //adjust most top edge
-                            if(zoneGeometry.x + zoneGeometry.width >= clientArea.width - halfPadding ) {                //adjust most right edge
-                                  zoneGeometry.width += halfPadding;
-                            }
-                            if(zoneGeometry.y + zoneGeometry.height >= clientArea.height - halfPadding ) {              //adjust most bottom edge
-                                zoneGeometry.height += halfPadding;
-                            }
-                            if (isPointInside(Workspace.cursorPos.x, Workspace.cursorPos.y, zoneGeometry)) {
-                                hoveringZone = zoneIndex;
-                            }
-                        });
+                        
+                        if (useClosestZoneCenter) {
+                            const zones = config.layouts[currentLayout].zones;
+                            hoveringZone = findClosestZone(zones, Workspace.cursorPos, clientArea);
+                        } else {
+                            currentZones.repeater.model.forEach((zone, zoneIndex) => {
+                                const zoneItem = currentZones.repeater.itemAt(zoneIndex);
+                                const itemGlobal = zoneItem.mapToGlobal(Qt.point(0, 0));
+                                let zoneGeometry = {
+                                    x: itemGlobal.x - padding/2,
+                                    y: itemGlobal.y - padding/2,
+                                    width: zoneItem.width + padding,
+                                    height: zoneItem.height + padding
+                                 };
+                                if(zoneGeometry.x <= halfPadding ) { zoneGeometry.x = 0; zoneGeometry.width += padding; }   //adjust most left edge
+                                if(zoneGeometry.y <= halfPadding ) { zoneGeometry.y = 0; zoneGeometry.height += padding; }  //adjust most top edge
+                                if(zoneGeometry.x + zoneGeometry.width >= clientArea.width - halfPadding ) {                //adjust most right edge
+                                      zoneGeometry.width += halfPadding;
+                                }
+                                if(zoneGeometry.y + zoneGeometry.height >= clientArea.height - halfPadding ) {              //adjust most bottom edge
+                                    zoneGeometry.height += halfPadding;
+                                }
+                                if (isPointInside(Workspace.cursorPos.x, Workspace.cursorPos.y, zoneGeometry)) {
+                                    hoveringZone = zoneIndex;
+                                }
+                            });
+                        }
                     }
                 }
 


### PR DESCRIPTION
I implemented this feature because it is available in Microsoft's PowerToys. I did not test any other Overlays but the problem I had with the current implementation is that windows can not be snapped to zones that are completely overlapped by other zones, for example zone `{
                &quot;x&quot;: 25,
                &quot;y&quot;: 0,
                &quot;height&quot;: 100,
                &quot;width&quot;: 50
            }` could not be snapped to because of zones `{
                &quot;x&quot;: 25,
                &quot;y&quot;: 0,
                &quot;height&quot;: 100,
                &quot;width&quot;: 25
            },
            {
                &quot;x&quot;: 50,
                &quot;y&quot;: 0,
                &quot;height&quot;: 100,
                &quot;width&quot;: 25
            }`
            
            