### PR TITLE
Add per-monitor default layout selection via `monitor` property

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -466,8 +466,6 @@ PlasmaCore.Dialog {
 
     function getDefaultScreenLayout(activeScreen) {
         for (let i = 0; i < config.layouts.length; i++) {
-            console.log(config.layouts[i].monitor)
-            console.log(activeScreen)
             if (config.layouts[i].monitor == activeScreen.name) {
                 return i;
             }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -464,11 +464,22 @@ PlasmaCore.Dialog {
         return targetZoneIndex;
     }
 
+    function getDefaultScreenLayout(activeScreen) {
+        for (let i = 0; i < config.layouts.length; i++) {
+            console.log(config.layouts[i].monitor)
+            console.log(activeScreen)
+            if (config.layouts[i].monitor == activeScreen.name) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
     function getCurrentLayout() {
         if (config.trackLayoutPerScreen) {
             const screenLayout = screenLayouts[Workspace.activeScreen.name]
             if (!screenLayout) {
-                screenLayouts[Workspace.activeScreen.name] = 0
+                screenLayouts[Workspace.activeScreen.name] = getDefaultScreenLayout(activeScreen);
             }
             return screenLayouts[Workspace.activeScreen.name];
         } else {


### PR DESCRIPTION
## Description

This PR adds support for per-monitor default layouts by introducing an optional "monitor" property in layout definitions.

When present, the layout is automatically selected as the default for the specified monitor on startup. This allows different monitors to use different default zone layouts without manual selection after login.

Configuration example
```
{
  "name": "Ultrawide layout",
  "padding": 0,
  "monitor": "DP-1",
  "zones": [
    ...
  ]
}
```

"monitor" matches the KWin output name

Layouts without this property behave exactly as before

## Behavior

On startup, KZones will assign layouts with a matching "monitor" to that output

Monitors without a match fall back to the first defined layout

If multiple layouts match the same monitor, the first one is used

This allows for multi-monitor setups to have separate defaults

## Compatibility

Fully backward compatible

No changes required to existing configs