### PR TITLE
Add track layout per virtual desktop option

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -46,6 +46,10 @@
             <default>false</default>
         </entry>
 
+        <entry name="trackLayoutPerDesktop" type="Bool">
+            <default>false</default>
+        </entry>
+
         <entry name="autoSnapAllNew" type="Bool">
             <default>false</default>
         </entry>

--- a/src/contents/ui/config.ui
+++ b/src/contents/ui/config.ui
@@ -293,6 +293,13 @@
                       </widget>
                     </item>
                     <item>
+                      <widget class="QCheckBox" name="kcfg_trackLayoutPerDesktop">
+                        <property name="text">
+                          <string>Track active layout per virtual desktop</string>
+                        </property>
+                      </widget>
+                    </item>
+                    <item>
                       <widget class="QCheckBox" name="kcfg_autoSnapAllNew">
                         <property name="text">
                           <string>Automatically snap all new windows</string>

--- a/src/contents/ui/js/core.mjs
+++ b/src/contents/ui/js/core.mjs
@@ -60,6 +60,7 @@ export function loadConfig() {
   config.edgeSnappingTriggerDistance = KWin.readConfig("edgeSnappingTriggerDistance", 1);
   config.rememberWindowGeometries = KWin.readConfig("rememberWindowGeometries", true);
   config.trackLayoutPerScreen = KWin.readConfig("trackLayoutPerScreen", false);
+  config.trackLayoutPerDesktop = KWin.readConfig("trackLayoutPerDesktop", false);
   config.showOsdMessages = KWin.readConfig("showOsdMessages", true);
   config.fadeWindowsWhileMoving = KWin.readConfig("fadeWindowsWhileMoving", false);
   config.autoSnapAllNew = KWin.readConfig("autoSnapAllNew", false);

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -299,23 +299,36 @@ Item {
         return targetZoneIndex;
     }
 
-    function getCurrentLayout() {
-        if (config.trackLayoutPerScreen) {
-            const screenLayout = screenLayouts[Workspace.activeScreen.name];
-            if (!screenLayout)
-                screenLayouts[Workspace.activeScreen.name] = 0;
+    function getLayoutKey() {
+        const parts = [];
+        if (config.trackLayoutPerScreen) parts.push(Workspace.activeScreen.name);
+        if (config.trackLayoutPerDesktop) parts.push(Workspace.currentDesktop.id);
+        return parts.join(':');
+    }
 
-            return screenLayouts[Workspace.activeScreen.name];
-        } else {
-            return currentLayout;
+    function getCurrentLayout() {
+        if (config.trackLayoutPerScreen || config.trackLayoutPerDesktop) {
+            const key = getLayoutKey();
+            if (!screenLayouts[key]) screenLayouts[key] = 0;
+            return screenLayouts[key];
         }
+        return currentLayout;
     }
 
     function setCurrentLayout(layout) {
-        if (config.trackLayoutPerScreen)
-            screenLayouts[Workspace.activeScreen.name] = layout;
-
+        if (config.trackLayoutPerScreen || config.trackLayoutPerDesktop) {
+            screenLayouts[getLayoutKey()] = layout;
+        }
         currentLayout = layout;
+    }
+
+    function osdLayoutName() {
+        const name = config.layouts[currentLayout].name;
+        const parts = [];
+        if (config.trackLayoutPerScreen) parts.push(Workspace.activeScreen.name);
+        if (config.trackLayoutPerDesktop) parts.push(Workspace.currentDesktop.name);
+        if (parts.length > 0) return `${name} (${parts.join(' / ')})`;
+        return name;
     }
 
     function checkFilter(client) {
@@ -660,12 +673,12 @@ Item {
         onCycleLayouts: {
             setCurrentLayout((currentLayout + 1) % config.layouts.length);
             highlightedZone = -1;
-            Utils.osd(config.trackLayoutPerScreen ? `${config.layouts[currentLayout].name} (${Workspace.activeScreen.name})` : config.layouts[currentLayout].name);
+            Utils.osd(osdLayoutName());
         }
         onCycleLayoutsReversed: {
             setCurrentLayout((currentLayout - 1 + config.layouts.length) % config.layouts.length);
             highlightedZone = -1;
-            Utils.osd(config.trackLayoutPerScreen ? `${config.layouts[currentLayout].name} (${Workspace.activeScreen.name})` : config.layouts[currentLayout].name);
+            Utils.osd(osdLayoutName());
         }
         onMoveActiveWindowToNextZone: {
             const client = Workspace.activeWindow;
@@ -704,7 +717,7 @@ Item {
             if (layout <= config.layouts.length - 1) {
                 setCurrentLayout(layout);
                 highlightedZone = -1;
-                Utils.osd(config.trackLayoutPerScreen ? `${config.layouts[currentLayout].name} (${Workspace.activeScreen.name})` : config.layouts[currentLayout].name);
+                Utils.osd(osdLayoutName());
             } else {
                 Utils.osd(`Layout ${layout + 1} does not exist`);
             }
@@ -747,6 +760,12 @@ Item {
 
     // workspace connection
     Connections {
+        function onCurrentDesktopChanged() {
+            if (config.trackLayoutPerDesktop) {
+                currentLayout = getCurrentLayout();
+            }
+        }
+
         function onWindowAdded(client) {
             connectSignals(client);
             // check if client is in a zone application list


### PR DESCRIPTION

- Adds a new config key `trackLayoutPerDesktop` and exposes it in the settings UI.
- Loads the flag into runtime config and uses it in the layout key (`getLayoutKey`) alongside `Workspace.currentDesktop.id` when enabled.
- Updates layout switching/OSD logic so the active layout is stored per desktop (using `screenLayouts[key]`) and the OSD shows the desktop name.

I tested this by building the script and using the "Install from File" in my KDE environment on EndeavourOS (KDE Plasma 6.6.0 on Wayland). I am able to have separate layouts for each monitor in each virtual desktops in a two monitor setup across four virtual desktops.